### PR TITLE
Fix modal sheet gesture handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,7 @@ lib/generated_plugin_registrant.dart
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+
+# Flutter SDK
+/flutter
+/flutter_linux_3.32.2-stable.tar.xz

--- a/lib/src/widgets/wolt_modal_sheet_drag_to_dismiss_detector.dart
+++ b/lib/src/widgets/wolt_modal_sheet_drag_to_dismiss_detector.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 class WoltModalSheetDragToDismissDetector extends StatelessWidget {
@@ -61,20 +62,34 @@ class WoltModalSheetDragToDismissDetector extends StatelessWidget {
         }
         return true;
       },
-      child: GestureDetector(
+      child: RawGestureDetector(
         excludeFromSemantics: true,
-        onVerticalDragUpdate: isVerticalDismissAllowed
-            ? (details) => _handleVerticalDragUpdate(details)
-            : null,
-        onVerticalDragEnd: isVerticalDismissAllowed
-            ? (details) => _handleVerticalDragEnd(context, details)
-            : null,
-        onHorizontalDragUpdate: isHorizontalDismissAllowed
-            ? (details) => _handleHorizontalDragUpdate(context, details)
-            : null,
-        onHorizontalDragEnd: isHorizontalDismissAllowed
-            ? (details) => _handleHorizontalDragEnd(context, details)
-            : null,
+        gestures: <Type, GestureRecognizerFactory<GestureRecognizer>>{
+          if (isVerticalDismissAllowed)
+            VerticalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<
+                VerticalDragGestureRecognizer>(
+              () => VerticalDragGestureRecognizer(debugOwner: this)
+                ..onlyAcceptDragOnThreshold = true,
+              (VerticalDragGestureRecognizer instance) {
+                instance
+                  ..onUpdate = _handleVerticalDragUpdate
+                  ..onEnd =
+                      (details) => _handleVerticalDragEnd(context, details);
+              },
+            ),
+          if (isHorizontalDismissAllowed)
+            HorizontalDragGestureRecognizer:
+                GestureRecognizerFactoryWithHandlers<
+                    HorizontalDragGestureRecognizer>(
+              () => HorizontalDragGestureRecognizer(debugOwner: this)
+                ..onlyAcceptDragOnThreshold = true,
+              (HorizontalDragGestureRecognizer instance) {
+                instance
+                  ..onUpdate = (details) => _handleHorizontalDragUpdate(context, details)
+                  ..onEnd = (details) => _handleHorizontalDragEnd(context, details);
+              },
+            ),
+        },
         child: child,
       ),
     );


### PR DESCRIPTION
## Summary
- route drag gestures through RawGestureDetector with customizable drag recognizers
- ignore local Flutter SDK artifacts

## Testing
- `flutter test` *(fails: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68493b7aa5708331b277052102b98c23